### PR TITLE
fix: prevent mobile header from being pushed into notification panel …

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -44,6 +44,23 @@ body {
   .mobile-header {
     padding: 0.75rem 1rem;
   }
+  
+  /* Fix mobile scroll header positioning */
+  .mobile-sticky-header {
+    position: sticky;
+    top: env(safe-area-inset-top, 0px);
+    z-index: 9999;
+    transform: translateZ(0); /* Force hardware acceleration */
+    -webkit-transform: translateZ(0);
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
+  }
+  
+  /* Ensure proper stacking context */
+  .mobile-content-wrapper {
+    position: relative;
+    z-index: 1;
+  }
 }
 
 /* Custom gradient backgrounds for different themes */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -56,7 +56,7 @@ export default function RootLayout({
         <AuthProvider>
           <div className="flex flex-col min-h-screen relative z-10">
             <Header />
-            <main className="flex-1 max-w-7xl mx-auto w-full px-4">{children}</main>
+            <main className="flex-1 max-w-7xl mx-auto w-full px-4 mobile-content-wrapper">{children}</main>
             <Footer />
           </div>
         </AuthProvider>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,7 +8,7 @@ export default function Header() {
   const { isAuthenticated, user, logout } = useAuth();
 
   return (
-    <header className="p-4 mobile-header shadow-lg bg-gradient-to-r from-blue-900/20 via-purple-900/20 to-blue-900/20 backdrop-blur-md border-b border-blue-500/30 sticky top-0 z-50 capacitor-header mobile-header-padding">
+    <header className="p-4 mobile-header shadow-lg bg-gradient-to-r from-blue-900/20 via-purple-900/20 to-blue-900/20 backdrop-blur-md border-b border-blue-500/30 md:sticky mobile-sticky-header md:top-0 z-50 capacitor-header mobile-header-padding">
       <div className="max-w-7xl mx-auto flex justify-between items-center">
         <Link href="/" className="flex items-center space-x-2 group hover:scale-105 transition-transform duration-200">
           <div className="relative">


### PR DESCRIPTION
…on scroll

Mobile Scroll Header Fixes:
- Use sticky positioning with proper safe-area-inset-top handling
- Add hardware acceleration with translateZ(0) and backface-visibility
- Set z-index to 9999 to ensure header stays above content
- Use env(safe-area-inset-top) for proper status bar positioning
- Different positioning strategy for mobile vs desktop (sticky only on desktop)
- Add proper stacking context for mobile content wrapper

Technical Changes:
- Mobile: sticky position with top: env(safe-area-inset-top)
- Desktop: standard sticky positioning with top: 0
- Enhanced CSS transforms for better mobile performance
- Proper z-index management to prevent header overlap issues

This ensures the header stays properly positioned relative to the safe area and doesn't get pushed into the notification panel when scrolling on mobile.